### PR TITLE
fix: bash path

### DIFF
--- a/colorscripts/alpha
+++ b/colorscripts/alpha
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Ivo
 # Source: http://crunchbang.org/forums/viewtopic.php?pid=134749#p134749
 
@@ -6,16 +6,16 @@ my_dir="$(dirname "$0")"
 source $(dirname $0)/initialise.sh
 initializeANSI
 
-cat << EOF  
-  
-${heejf}  ████  ${reset} ${hyunf}██████  ${reset} ${hasef}  ██████${reset} ${yeojf}██████  ${reset} ${vivif}████████${reset} ${kimlf}████████${reset} 
+cat << EOF
+
+${heejf}  ████  ${reset} ${hyunf}██████  ${reset} ${hasef}  ██████${reset} ${yeojf}██████  ${reset} ${vivif}████████${reset} ${kimlf}████████${reset}
 ${heejf}██    ██${reset} ${hyunf}██    ██${reset} ${hasef}██      ${reset} ${yeojf}██    ██${reset} ${vivif}████████${reset} ${kimlf}██      ${reset}
 ${heejf}████████${reset} ${hyunf}██  ████${reset} ${hasef}██      ${reset} ${yeojf}██    ██${reset} ${vivif}██      ${reset} ${kimlf}██████  ${reset}
 ${heejf}██    ██${reset} ${hyunf}██████  ${reset} ${hasef}  ██████${reset} ${yeojf}██████  ${reset} ${vivif}████████${reset} ${kimlf}██      ${reset}
 
-${jinsf}████████${reset} ${choef}██    ██${reset} ${yvesf}████████${reset} ${chuuf}████████${reset} ${gowof}██   ███${reset} ${olivf}██      ${reset} 
+${jinsf}████████${reset} ${choef}██    ██${reset} ${yvesf}████████${reset} ${chuuf}████████${reset} ${gowof}██   ███${reset} ${olivf}██      ${reset}
 ${jinsf}██      ${reset} ${choef}██    ██${reset} ${yvesf}   ██   ${reset} ${chuuf}   ██   ${reset} ${gowof}█████   ${reset} ${olivf}██      ${reset}
 ${jinsf}██   ███${reset} ${choef}████████${reset} ${yvesf}   ██   ${reset} ${chuuf}██ ██   ${reset} ${gowof}█████   ${reset} ${olivf}██      ${reset}
-${jinsf}████████${reset} ${choef}██    ██${reset} ${yvesf}████████${reset} ${chuuf}█████   ${reset} ${gowof}██   ███${reset} ${olivf}████████${reset} 
- 
+${jinsf}████████${reset} ${choef}██    ██${reset} ${yvesf}████████${reset} ${chuuf}█████   ${reset} ${gowof}██   ███${reset} ${olivf}████████${reset}
+
 EOF

--- a/colorscripts/arch
+++ b/colorscripts/arch
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Ivo
 # Source: http://crunchbang.org/forums/viewtopic.php?pid=237794#p237794
 
@@ -6,8 +6,8 @@ my_dir="$(dirname "$0")"
 source $(dirname $0)/initialise.sh
 initializeANSI
 
-cat << EOF 
-  
+cat << EOF
+
 ${heejf}        ■      ${hyunf}        ■      ${hasef}        ■      ${yeojf}        ■       ${vivif}       ■      ${kimlf}        ■      ${reset}
 ${heejf}       ■■■     ${hyunf}       ■■■     ${hasef}       ■■■     ${yeojf}       ■■■      ${vivif}      ■■■     ${kimlf}       ■■■     ${reset}
 ${heejf}      ■■■■■    ${hyunf}      ■■■■■    ${hasef}      ■■■■■    ${yeojf}      ■■■■■     ${vivif}     ■■■■■    ${kimlf}      ■■■■■    ${reset}
@@ -21,5 +21,5 @@ ${jinsf}      ■■■■■    ${choef}      ■■■■■    ${yvesf}      
 ${jinsf}     ■(   )■   ${choef}     ■(   )■   ${yvesf}     ■(   )■   ${chuuf}     ■(   )■    ${gowof}    ■(   )■   ${olivf}     ■(   )■   ${reset}
 ${jinsf}    ■■■■ ■■■■  ${choef}    ■■■■ ■■■■  ${yvesf}    ■■■■ ■■■■  ${chuuf}    ■■■■ ■■■■   ${gowof}   ■■■■ ■■■■  ${olivf}    ■■■■ ■■■■  ${reset}
 ${jinsf}   ■■       ■■ ${choef}   ■■       ■■ ${yvesf}   ■■       ■■ ${chuuf}   ■■       ■■  ${gowof}  ■■       ■■ ${olivf}   ■■       ■■ ${reset}
- 
+
 EOF

--- a/colorscripts/bars
+++ b/colorscripts/bars
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ANSI color scheme script by pfh
 # Source: http://crunchbang.org/forums/viewtopic.php?pid=139126#p139126
 # Initializing mod by lolilolicon from Archlinux

--- a/colorscripts/blocks1
+++ b/colorscripts/blocks1
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 my_dir="$(dirname "$0")"
 source $(dirname $0)/initialise.sh
 

--- a/colorscripts/bloks
+++ b/colorscripts/bloks
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 my_dir="$(dirname "$0")"
 source $(dirname $0)/initialise.sh
@@ -7,7 +7,7 @@ initializeANSI
 
 cat << EOF
 ${heejf}11111111${reset} ${hyunf}22222222${reset} ${hasef}33333333${reset} ${yeojf}44444444${reset} ${vivif}55555555${reset} ${kimlf}66666666${reset} ${jinsf}77777777${reset} ${choef}88888888${reset} ${yvesf}99999999${reset} ${chuuf}00000000${reset} ${gowof}AAAAAAAA${reset} ${olivf}BBBBBBBB${reset}
-${heejf}████████${reset} ${hyunf}████████${reset} ${hasef}████████${reset} ${yeojf}████████${reset} ${vivif}████████${reset} ${kimlf}████████${reset} ${jinsf}████████${reset} ${choef}████████${reset} ${yvesf}████████${reset} ${chuuf}████████${reset} ${gowof}████████${reset} ${olivf}████████${reset} 
-${heejf}████████${reset} ${hyunf}████████${reset} ${hasef}████████${reset} ${yeojf}████████${reset} ${vivif}████████${reset} ${kimlf}████████${reset} ${jinsf}████████${reset} ${choef}████████${reset} ${yvesf}████████${reset} ${chuuf}████████${reset} ${gowof}████████${reset} ${olivf}████████${reset} 
-${heejf}████████${reset} ${hyunf}████████${reset} ${hasef}████████${reset} ${yeojf}████████${reset} ${vivif}████████${reset} ${kimlf}████████${reset} ${jinsf}████████${reset} ${choef}████████${reset} ${yvesf}████████${reset} ${chuuf}████████${reset} ${gowof}████████${reset} ${olivf}████████${reset} 
+${heejf}████████${reset} ${hyunf}████████${reset} ${hasef}████████${reset} ${yeojf}████████${reset} ${vivif}████████${reset} ${kimlf}████████${reset} ${jinsf}████████${reset} ${choef}████████${reset} ${yvesf}████████${reset} ${chuuf}████████${reset} ${gowof}████████${reset} ${olivf}████████${reset}
+${heejf}████████${reset} ${hyunf}████████${reset} ${hasef}████████${reset} ${yeojf}████████${reset} ${vivif}████████${reset} ${kimlf}████████${reset} ${jinsf}████████${reset} ${choef}████████${reset} ${yvesf}████████${reset} ${chuuf}████████${reset} ${gowof}████████${reset} ${olivf}████████${reset}
+${heejf}████████${reset} ${hyunf}████████${reset} ${hasef}████████${reset} ${yeojf}████████${reset} ${vivif}████████${reset} ${kimlf}████████${reset} ${jinsf}████████${reset} ${choef}████████${reset} ${yvesf}████████${reset} ${chuuf}████████${reset} ${gowof}████████${reset} ${olivf}████████${reset}
 EOF

--- a/colorscripts/crunch
+++ b/colorscripts/crunch
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: gutterslob
 # Source: http://crunchbang.org/forums/viewtopic.php?pid=148022#p148022
 
@@ -7,17 +7,17 @@ source $(dirname $0)/initialise.sh
 initializeANSI
 
 cat << EOF
- 
- ${heejf}  ██  ██   ${hyunf}   ██  ██   ${hasef}   ██  ██   ${yeojf}   ██  ██   ${vivif}   ██  ██   ${kimlf}   ██  ██   
- ${heejf}██████████ ${hyunf} ██████████ ${hasef} ██████████ ${yeojf} ██████████ ${vivif} ██████████ ${kimlf} ██████████ 
- ${heejf}  ██████   ${hyunf}   ██████   ${hasef}   ██████   ${yeojf}   ██████   ${vivif}   ██████   ${kimlf}   ██████   
- ${heejf}██████████ ${hyunf} ██████████ ${hasef} ██████████ ${yeojf} ██████████ ${vivif} ██████████ ${kimlf} ██████████
- ${heejf}  ██  ██   ${hyunf}   ██  ██   ${hasef}   ██  ██   ${yeojf}   ██  ██   ${vivif}   ██  ██   ${kimlf}   ██  ██   
 
- ${jinsf}  ██  ██   ${choef}   ██  ██   ${yvesf}   ██  ██   ${chuuf}   ██  ██   ${gowof}   ██  ██   ${olivf}   ██  ██   
- ${jinsf}██████████ ${choef} ██████████ ${yvesf} ██████████ ${chuuf} ██████████ ${gowof} ██████████ ${olivf} ██████████ 
- ${jinsf}  ██████   ${choef}   ██████   ${yvesf}   ██████   ${chuuf}   ██████   ${gowof}   ██████   ${olivf}   ██████   
- ${jinsf}██████████ ${choef} ██████████ ${yvesf} ██████████ ${chuuf} ██████████ ${gowof} ██████████ ${olivf} ██████████ 
- ${jinsf}  ██  ██   ${choef}   ██  ██   ${yvesf}   ██  ██   ${chuuf}   ██  ██   ${gowof}   ██  ██   ${olivf}   ██  ██   
- 
+ ${heejf}  ██  ██   ${hyunf}   ██  ██   ${hasef}   ██  ██   ${yeojf}   ██  ██   ${vivif}   ██  ██   ${kimlf}   ██  ██
+ ${heejf}██████████ ${hyunf} ██████████ ${hasef} ██████████ ${yeojf} ██████████ ${vivif} ██████████ ${kimlf} ██████████
+ ${heejf}  ██████   ${hyunf}   ██████   ${hasef}   ██████   ${yeojf}   ██████   ${vivif}   ██████   ${kimlf}   ██████
+ ${heejf}██████████ ${hyunf} ██████████ ${hasef} ██████████ ${yeojf} ██████████ ${vivif} ██████████ ${kimlf} ██████████
+ ${heejf}  ██  ██   ${hyunf}   ██  ██   ${hasef}   ██  ██   ${yeojf}   ██  ██   ${vivif}   ██  ██   ${kimlf}   ██  ██
+
+ ${jinsf}  ██  ██   ${choef}   ██  ██   ${yvesf}   ██  ██   ${chuuf}   ██  ██   ${gowof}   ██  ██   ${olivf}   ██  ██
+ ${jinsf}██████████ ${choef} ██████████ ${yvesf} ██████████ ${chuuf} ██████████ ${gowof} ██████████ ${olivf} ██████████
+ ${jinsf}  ██████   ${choef}   ██████   ${yvesf}   ██████   ${chuuf}   ██████   ${gowof}   ██████   ${olivf}   ██████
+ ${jinsf}██████████ ${choef} ██████████ ${yvesf} ██████████ ${chuuf} ██████████ ${gowof} ██████████ ${olivf} ██████████
+ ${jinsf}  ██  ██   ${choef}   ██  ██   ${yvesf}   ██  ██   ${chuuf}   ██  ██   ${gowof}   ██  ██   ${olivf}   ██  ██
+
 EOF

--- a/colorscripts/crunchbang
+++ b/colorscripts/crunchbang
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: steampunknyanja
 # Source: http://crunchbang.org/forums/viewtopic.php?pid=146715#p146715
 
@@ -10,13 +10,13 @@ cat << EOF
  ${heejf}  ██  ██   ${heejf}██    ${hyunf}  ██  ██   ${hyunf}██    ${hasef}  ██  ██   ${hasef}██    ${yeojf}  ██  ██   ${yeojf}██    ${vivif}  ██  ██   ${vivif}██    ${kimlf}  ██  ██   ${kimlf}██
  ${heejf}██████████ ${heejf}██    ${hyunf}██████████ ${hyunf}██    ${hasef}██████████ ${hasef}██    ${yeojf}██████████ ${yeojf}██    ${vivif}██████████ ${vivif}██    ${kimlf}██████████ ${kimlf}██
  ${heejf}  ██  ██   ${heejf}██    ${hyunf}  ██  ██   ${hyunf}██    ${hasef}  ██  ██   ${hasef}██    ${yeojf}  ██  ██   ${yeojf}██    ${vivif}  ██  ██   ${vivif}██    ${kimlf}  ██  ██   ${kimlf}██
- ${heejf}██████████       ${hyunf}██████████       ${hasef}██████████       ${yeojf}██████████       ${vivif}██████████       ${kimlf}██████████   
- ${heejf}  ██  ██   ${heejf}██    ${hyunf}  ██  ██   ${hyunf}██    ${hasef}  ██  ██   ${hasef}██    ${yeojf}  ██  ██   ${yeojf}██    ${vivif}  ██  ██   ${vivif}██    ${kimlf}  ██  ██   ${kimlf}██ 
+ ${heejf}██████████       ${hyunf}██████████       ${hasef}██████████       ${yeojf}██████████       ${vivif}██████████       ${kimlf}██████████
+ ${heejf}  ██  ██   ${heejf}██    ${hyunf}  ██  ██   ${hyunf}██    ${hasef}  ██  ██   ${hasef}██    ${yeojf}  ██  ██   ${yeojf}██    ${vivif}  ██  ██   ${vivif}██    ${kimlf}  ██  ██   ${kimlf}██
 
  ${jinsf}  ██  ██   ${jinsf}██    ${choef}  ██  ██   ${choef}██    ${yvesf}  ██  ██   ${yvesf}██    ${chuuf}  ██  ██   ${chuuf}██    ${gowof}  ██  ██   ${gowof}██    ${olivf}  ██  ██   ${olivf}██
  ${jinsf}██████████ ${jinsf}██    ${choef}██████████ ${choef}██    ${yvesf}██████████ ${yvesf}██    ${chuuf}██████████ ${chuuf}██    ${gowof}██████████ ${gowof}██    ${olivf}██████████ ${olivf}██
  ${jinsf}  ██  ██   ${jinsf}██    ${choef}  ██  ██   ${choef}██    ${yvesf}  ██  ██   ${yvesf}██    ${chuuf}  ██  ██   ${chuuf}██    ${gowof}  ██  ██   ${gowof}██    ${olivf}  ██  ██   ${olivf}██
- ${jinsf}██████████       ${choef}██████████       ${yvesf}██████████       ${chuuf}██████████       ${gowof}██████████       ${olivf}██████████   
- ${jinsf}  ██  ██   ${jinsf}██    ${choef}  ██  ██   ${choef}██    ${yvesf}  ██  ██   ${yvesf}██    ${chuuf}  ██  ██   ${chuuf}██    ${gowof}  ██  ██   ${gowof}██    ${olivf}  ██  ██   ${olivf}██ 
+ ${jinsf}██████████       ${choef}██████████       ${yvesf}██████████       ${chuuf}██████████       ${gowof}██████████       ${olivf}██████████
+ ${jinsf}  ██  ██   ${jinsf}██    ${choef}  ██  ██   ${choef}██    ${yvesf}  ██  ██   ${yvesf}██    ${chuuf}  ██  ██   ${chuuf}██    ${gowof}  ██  ██   ${gowof}██    ${olivf}  ██  ██   ${olivf}██
 
 EOF

--- a/colorscripts/crunchbang-mini
+++ b/colorscripts/crunchbang-mini
@@ -1,5 +1,5 @@
-#!/bin/bash
-# Author: thevdude 
+#!/usr/bin/env bash
+# Author: thevdude
 # Source: http://crunchbang.org/forums/viewtopic.php?pid=147530#p147530
 
 my_dir="$(dirname "$0")"
@@ -8,11 +8,11 @@ initializeANSI
 
 cat << EOF
  ${heejf}▄█▄█▄ ${heejf}█ ${hyunf}▄█▄█▄ ${hyunf}█ ${hasef}▄█▄█▄ ${hasef}█ ${yeojf}▄█▄█▄ ${yeojf}█ ${vivif}▄█▄█▄ ${vivif}█ ${kimlf}▄█▄█▄ ${kimlf}█
- ${heejf}▄█▄█▄ ${heejf}▀ ${hyunf}▄█▄█▄ ${hyunf}▀ ${hasef}▄█▄█▄ ${hasef}▀ ${yeojf}▄█▄█▄ ${yeojf}▀ ${vivif}▄█▄█▄ ${vivif}▀ ${kimlf}▄█▄█▄ ${kimlf}▀ 
- ${heejf} ▀ ▀  ${heejf}▀ ${hyunf} ▀ ▀  ${hyunf}▀ ${hasef} ▀ ▀  ${hasef}▀ ${yeojf} ▀ ▀  ${yeojf}▀ ${vivif} ▀ ▀  ${vivif}▀ ${kimlf} ▀ ▀  ${kimlf}▀ 
+ ${heejf}▄█▄█▄ ${heejf}▀ ${hyunf}▄█▄█▄ ${hyunf}▀ ${hasef}▄█▄█▄ ${hasef}▀ ${yeojf}▄█▄█▄ ${yeojf}▀ ${vivif}▄█▄█▄ ${vivif}▀ ${kimlf}▄█▄█▄ ${kimlf}▀
+ ${heejf} ▀ ▀  ${heejf}▀ ${hyunf} ▀ ▀  ${hyunf}▀ ${hasef} ▀ ▀  ${hasef}▀ ${yeojf} ▀ ▀  ${yeojf}▀ ${vivif} ▀ ▀  ${vivif}▀ ${kimlf} ▀ ▀  ${kimlf}▀
 
  ${jinsf}▄█▄█▄ ${jinsf}█ ${choef}▄█▄█▄ ${choef}█ ${yvesf}▄█▄█▄ ${yvesf}█ ${chuuf}▄█▄█▄ ${chuuf}█ ${gowof}▄█▄█▄ ${gowof}█ ${olivf}▄█▄█▄ ${olivf}█
- ${jinsf}▄█▄█▄ ${jinsf}▀ ${choef}▄█▄█▄ ${choef}▀ ${yvesf}▄█▄█▄ ${yvesf}▀ ${chuuf}▄█▄█▄ ${chuuf}▀ ${gowof}▄█▄█▄ ${gowof}▀ ${olivf}▄█▄█▄ ${olivf}▀ 
- ${jinsf} ▀ ▀  ${jinsf}▀ ${choef} ▀ ▀  ${choef}▀ ${yvesf} ▀ ▀  ${yvesf}▀ ${chuuf} ▀ ▀  ${chuuf}▀ ${gowof} ▀ ▀  ${gowof}▀ ${olivf} ▀ ▀  ${olivf}▀  
+ ${jinsf}▄█▄█▄ ${jinsf}▀ ${choef}▄█▄█▄ ${choef}▀ ${yvesf}▄█▄█▄ ${yvesf}▀ ${chuuf}▄█▄█▄ ${chuuf}▀ ${gowof}▄█▄█▄ ${gowof}▀ ${olivf}▄█▄█▄ ${olivf}▀
+ ${jinsf} ▀ ▀  ${jinsf}▀ ${choef} ▀ ▀  ${choef}▀ ${yvesf} ▀ ▀  ${yvesf}▀ ${chuuf} ▀ ▀  ${chuuf}▀ ${gowof} ▀ ▀  ${gowof}▀ ${olivf} ▀ ▀  ${olivf}▀
 
 EOF

--- a/colorscripts/dna
+++ b/colorscripts/dna
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ANSI color scheme script by pfh
 # Source: http://crunchbang.org/forums/viewtopic.php?pid=144011#p144011
 # Initializing mod by lolilolicon from Archlinux
@@ -14,7 +14,7 @@ cat << EOF
   ${heejf} █-$bld█$rst     ${hyunf} █-$bld█$rst     ${hasef} █-$bld█$rst     ${yeojf} █-$bld█$rst     ${vivif} █-$bld█$rst     ${kimlf} █-$bld█$rst
     ${heejf}█$rst        ${hyunf}█$rst        ${hasef}█$rst        ${yeojf}█$rst        ${vivif}█$rst        ${kimlf}█$rst
    ${heejf}$bld█-$rst${heejf}█$rst      ${hyunf}$bld█_$rst${hyunf}█$rst      ${hasef}$bld█-$rst${hasef}█$rst      ${yeojf}$bld█-$rst${yeojf}█$rst      ${vivif}$bld█-$rst${vivif}█$rst      ${kimlf}$bld█-$rst${kimlf}█$rst
-  ${heejf}$bld█---$rst${heejf}█$rst    ${hyunf}$bld█---$rst${hyunf}█$rst    ${hasef}$bld█---$rst${hasef}█$rst    ${yeojf}$bld█---$rst${yeojf}█$rst    ${vivif}$bld█---$rst${vivif}█$rst    ${kimlf}$bld█---$rst${kimlf}█$rst 
+  ${heejf}$bld█---$rst${heejf}█$rst    ${hyunf}$bld█---$rst${hyunf}█$rst    ${hasef}$bld█---$rst${hasef}█$rst    ${yeojf}$bld█---$rst${yeojf}█$rst    ${vivif}$bld█---$rst${vivif}█$rst    ${kimlf}$bld█---$rst${kimlf}█$rst
  ${heejf}$bld█-----$rst${heejf}█$rst  ${hyunf}$bld█-----$rst${hyunf}█$rst  ${hasef}$bld█-----$rst${hasef}█$rst  ${yeojf}$bld█-----$rst${yeojf}█$rst  ${vivif}$bld█-----$rst${vivif}█$rst  ${kimlf}$bld█-----$rst${kimlf}█$rst
   ${heejf}$bld█---$rst${heejf}█$rst    ${hyunf}$bld█---$rst${hyunf}█$rst    ${hasef}$bld█---$rst${hasef}█$rst    ${yeojf}$bld█---$rst${yeojf}█$rst    ${vivif}$bld█---$rst${vivif}█$rst    ${kimlf}$bld█---$rst${kimlf}█$rst
    ${heejf}$bld█-$rst${heejf}█$rst      ${hyunf}$bld█-$rst${hyunf}█$rst      ${hasef}$bld█-$rst${hasef}█$rst      ${yeojf}$bld█-$rst${yeojf}█$rst      ${vivif}$bld█-$rst${vivif}█$rst      ${kimlf}$bld█-$rst${kimlf}█$rst
@@ -26,7 +26,7 @@ cat << EOF
   ${heejf} █-$bld█$rst     ${hyunf} █-$bld█$rst     ${hasef} █-$bld█$rst     ${yeojf} █-$bld█$rst     ${vivif} █-$bld█$rst     ${kimlf} █-$bld█$rst
     ${heejf}█$rst        ${hyunf}█$rst        ${hasef}█$rst        ${yeojf}█$rst        ${vivif}█$rst        ${kimlf}█$rst
    ${heejf}$bld█-$rst${heejf}█$rst      ${hyunf}$bld█_$rst${hyunf}█$rst      ${hasef}$bld█-$rst${hasef}█$rst      ${yeojf}$bld█-$rst${yeojf}█$rst      ${vivif}$bld█-$rst${vivif}█$rst      ${kimlf}$bld█-$rst${kimlf}█$rst
-  ${heejf}$bld█---$rst${heejf}█$rst    ${hyunf}$bld█---$rst${hyunf}█$rst    ${hasef}$bld█---$rst${hasef}█$rst    ${yeojf}$bld█---$rst${yeojf}█$rst    ${vivif}$bld█---$rst${vivif}█$rst    ${kimlf}$bld█---$rst${kimlf}█$rst 
+  ${heejf}$bld█---$rst${heejf}█$rst    ${hyunf}$bld█---$rst${hyunf}█$rst    ${hasef}$bld█---$rst${hasef}█$rst    ${yeojf}$bld█---$rst${yeojf}█$rst    ${vivif}$bld█---$rst${vivif}█$rst    ${kimlf}$bld█---$rst${kimlf}█$rst
  ${heejf}$bld█-----$rst${heejf}█$rst  ${hyunf}$bld█-----$rst${hyunf}█$rst  ${hasef}$bld█-----$rst${hasef}█$rst  ${yeojf}$bld█-----$rst${yeojf}█$rst  ${vivif}$bld█-----$rst${vivif}█$rst  ${kimlf}$bld█-----$rst${kimlf}█$rst
   ${heejf}$bld█---$rst${heejf}█$rst    ${hyunf}$bld█---$rst${hyunf}█$rst    ${hasef}$bld█---$rst${hasef}█$rst    ${yeojf}$bld█---$rst${yeojf}█$rst    ${vivif}$bld█---$rst${vivif}█$rst    ${kimlf}$bld█---$rst${kimlf}█$rst
    ${heejf}$bld█-$rst${heejf}█$rst      ${hyunf}$bld█-$rst${hyunf}█$rst      ${hasef}$bld█-$rst${hasef}█$rst      ${yeojf}$bld█-$rst${yeojf}█$rst      ${vivif}$bld█-$rst${vivif}█$rst      ${kimlf}$bld█-$rst${kimlf}█$rst
@@ -40,7 +40,7 @@ cat << EOF
   ${jinsf} █-$bld█$rst     ${choef} █-$bld█$rst     ${yvesf} █-$bld█$rst     ${chuuf} █-$bld█$rst     ${gowof} █-$bld█$rst     ${olivf} █-$bld█$rst
     ${jinsf}█$rst        ${choef}█$rst        ${yvesf}█$rst        ${chuuf}█$rst        ${gowof}█$rst        ${olivf}█$rst
    ${jinsf}$bld█-$rst${jinsf}█$rst      ${choef}$bld█_$rst${choef}█$rst      ${yvesf}$bld█-$rst${yvesf}█$rst      ${chuuf}$bld█-$rst${chuuf}█$rst      ${gowof}$bld█-$rst${gowof}█$rst      ${olivf}$bld█-$rst${olivf}█$rst
-  ${jinsf}$bld█---$rst${jinsf}█$rst    ${choef}$bld█---$rst${choef}█$rst    ${yvesf}$bld█---$rst${yvesf}█$rst    ${chuuf}$bld█---$rst${chuuf}█$rst    ${gowof}$bld█---$rst${gowof}█$rst    ${olivf}$bld█---$rst${olivf}█$rst 
+  ${jinsf}$bld█---$rst${jinsf}█$rst    ${choef}$bld█---$rst${choef}█$rst    ${yvesf}$bld█---$rst${yvesf}█$rst    ${chuuf}$bld█---$rst${chuuf}█$rst    ${gowof}$bld█---$rst${gowof}█$rst    ${olivf}$bld█---$rst${olivf}█$rst
  ${jinsf}$bld█-----$rst${jinsf}█$rst  ${choef}$bld█-----$rst${choef}█$rst  ${yvesf}$bld█-----$rst${yvesf}█$rst  ${chuuf}$bld█-----$rst${chuuf}█$rst  ${gowof}$bld█-----$rst${gowof}█$rst  ${olivf}$bld█-----$rst${olivf}█$rst
   ${jinsf}$bld█---$rst${jinsf}█$rst    ${choef}$bld█---$rst${choef}█$rst    ${yvesf}$bld█---$rst${yvesf}█$rst    ${chuuf}$bld█---$rst${chuuf}█$rst    ${gowof}$bld█---$rst${gowof}█$rst    ${olivf}$bld█---$rst${olivf}█$rst
    ${jinsf}$bld█-$rst${jinsf}█$rst      ${choef}$bld█-$rst${choef}█$rst      ${yvesf}$bld█-$rst${yvesf}█$rst      ${chuuf}$bld█-$rst${chuuf}█$rst      ${gowof}$bld█-$rst${gowof}█$rst      ${olivf}$bld█-$rst${olivf}█$rst
@@ -53,7 +53,7 @@ cat << EOF
   ${jinsf} █-$bld█$rst     ${choef} █-$bld█$rst     ${yvesf} █-$bld█$rst     ${chuuf} █-$bld█$rst     ${gowof} █-$bld█$rst     ${olivf} █-$bld█$rst
     ${jinsf}█$rst        ${choef}█$rst        ${yvesf}█$rst        ${chuuf}█$rst        ${gowof}█$rst        ${olivf}█$rst
    ${jinsf}$bld█-$rst${jinsf}█$rst      ${choef}$bld█_$rst${choef}█$rst      ${yvesf}$bld█-$rst${yvesf}█$rst      ${chuuf}$bld█-$rst${chuuf}█$rst      ${gowof}$bld█-$rst${gowof}█$rst      ${olivf}$bld█-$rst${olivf}█$rst
-  ${jinsf}$bld█---$rst${jinsf}█$rst    ${choef}$bld█---$rst${choef}█$rst    ${yvesf}$bld█---$rst${yvesf}█$rst    ${chuuf}$bld█---$rst${chuuf}█$rst    ${gowof}$bld█---$rst${gowof}█$rst    ${olivf}$bld█---$rst${olivf}█$rst 
+  ${jinsf}$bld█---$rst${jinsf}█$rst    ${choef}$bld█---$rst${choef}█$rst    ${yvesf}$bld█---$rst${yvesf}█$rst    ${chuuf}$bld█---$rst${chuuf}█$rst    ${gowof}$bld█---$rst${gowof}█$rst    ${olivf}$bld█---$rst${olivf}█$rst
  ${jinsf}$bld█-----$rst${jinsf}█$rst  ${choef}$bld█-----$rst${choef}█$rst  ${yvesf}$bld█-----$rst${yvesf}█$rst  ${chuuf}$bld█-----$rst${chuuf}█$rst  ${gowof}$bld█-----$rst${gowof}█$rst  ${olivf}$bld█-----$rst${olivf}█$rst
   ${jinsf}$bld█---$rst${jinsf}█$rst    ${choef}$bld█---$rst${choef}█$rst    ${yvesf}$bld█---$rst${yvesf}█$rst    ${chuuf}$bld█---$rst${chuuf}█$rst    ${gowof}$bld█---$rst${gowof}█$rst    ${olivf}$bld█---$rst${olivf}█$rst
    ${jinsf}$bld█-$rst${jinsf}█$rst      ${choef}$bld█-$rst${choef}█$rst      ${yvesf}$bld█-$rst${yvesf}█$rst      ${chuuf}$bld█-$rst${chuuf}█$rst      ${gowof}$bld█-$rst${gowof}█$rst      ${olivf}$bld█-$rst${olivf}█$rst
@@ -61,5 +61,5 @@ cat << EOF
    ${jinsf}█-$bld█$rst      ${choef}█-$bld█$rst      ${yvesf}█-$bld█$rst      ${chuuf}█-$bld█$rst      ${gowof}█-$bld█$rst      ${olivf}█-$bld█$rst
   ${jinsf}█---$bld█$rst    ${choef}█---$bld█$rst    ${yvesf}█---$bld█$rst    ${chuuf}█---$bld█$rst    ${gowof}█---$bld█$rst    ${olivf}█---$bld█$rst
  ${jinsf}█-----$bld█  $rst${choef}█-----$bld█$rst  ${yvesf}█-----$bld█$rst  ${chuuf}█-----$bld█$rst  ${gowof}█-----$bld█$rst  ${olivf}█-----$bld█$rst
-  
+
 EOF

--- a/colorscripts/faces
+++ b/colorscripts/faces
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: pfh
 # Source: http://crunchbang.org/forums/viewtopic.php?pid=127737#p127737
 

--- a/colorscripts/fade
+++ b/colorscripts/fade
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: pfh
 # Source: http://crunchbang.org/forums/viewtopic.php?pid=127737#p127737
 
@@ -8,12 +8,12 @@ initializeANSI
 
 cat << EOF
 
- ${heejf}▒▒▒▒${reset} ${boldon}${heejf}▒▒${reset}   ${hyunf}▒▒▒▒${reset} ${boldon}${hyunf}▒▒${reset}   ${hasef}▒▒▒▒${reset} ${boldon}${hasef}▒▒${reset}   ${yeojf}▒▒▒▒${reset} ${boldon}${yeojf}▒▒${reset}   ${vivif}▒▒▒▒${reset} ${boldon}${vivif}▒▒${reset}   ${kimlf}▒▒▒▒${reset} ${boldon}${kimlf}▒▒${reset} 
- ${heejf}▒▒ ■${reset} ${boldon}${heejf}▒▒${reset}   ${hyunf}▒▒ ■${reset} ${boldon}${hyunf}▒▒${reset}   ${hasef}▒▒ ■${reset} ${boldon}${hasef}▒▒${reset}   ${yeojf}▒▒ ■${reset} ${boldon}${yeojf}▒▒${reset}   ${vivif}▒▒ ■${reset} ${boldon}${vivif}▒▒${reset}   ${kimlf}▒▒ ■${reset} ${boldon}${kimlf}▒▒${reset}  
+ ${heejf}▒▒▒▒${reset} ${boldon}${heejf}▒▒${reset}   ${hyunf}▒▒▒▒${reset} ${boldon}${hyunf}▒▒${reset}   ${hasef}▒▒▒▒${reset} ${boldon}${hasef}▒▒${reset}   ${yeojf}▒▒▒▒${reset} ${boldon}${yeojf}▒▒${reset}   ${vivif}▒▒▒▒${reset} ${boldon}${vivif}▒▒${reset}   ${kimlf}▒▒▒▒${reset} ${boldon}${kimlf}▒▒${reset}
+ ${heejf}▒▒ ■${reset} ${boldon}${heejf}▒▒${reset}   ${hyunf}▒▒ ■${reset} ${boldon}${hyunf}▒▒${reset}   ${hasef}▒▒ ■${reset} ${boldon}${hasef}▒▒${reset}   ${yeojf}▒▒ ■${reset} ${boldon}${yeojf}▒▒${reset}   ${vivif}▒▒ ■${reset} ${boldon}${vivif}▒▒${reset}   ${kimlf}▒▒ ■${reset} ${boldon}${kimlf}▒▒${reset}
  ${heejf}▒▒ ${reset}${boldon}${heejf}▒▒▒▒${reset}   ${hyunf}▒▒ ${reset}${boldon}${hyunf}▒▒▒▒${reset}   ${hasef}▒▒ ${reset}${boldon}${hasef}▒▒▒▒${reset}   ${yeojf}▒▒ ${reset}${boldon}${yeojf}▒▒▒▒${reset}   ${vivif}▒▒ ${reset}${boldon}${vivif}▒▒▒▒${reset}   ${kimlf}▒▒ ${reset}${boldon}${kimlf}▒▒▒▒${reset}
 
- ${jinsf}▒▒▒▒${reset} ${boldon}${jinsf}▒▒${reset}   ${choef}▒▒▒▒${reset} ${boldon}${choef}▒▒${reset}   ${yvesf}▒▒▒▒${reset} ${boldon}${yvesf}▒▒${reset}   ${chuuf}▒▒▒▒${reset} ${boldon}${chuuf}▒▒${reset}   ${gowof}▒▒▒▒${reset} ${boldon}${gowof}▒▒${reset}   ${olivf}▒▒▒▒${reset} ${boldon}${olivf}▒▒${reset} 
- ${jinsf}▒▒ ■${reset} ${boldon}${jinsf}▒▒${reset}   ${choef}▒▒ ■${reset} ${boldon}${choef}▒▒${reset}   ${yvesf}▒▒ ■${reset} ${boldon}${yvesf}▒▒${reset}   ${chuuf}▒▒ ■${reset} ${boldon}${chuuf}▒▒${reset}   ${gowof}▒▒ ■${reset} ${boldon}${gowof}▒▒${reset}   ${olivf}▒▒ ■${reset} ${boldon}${olivf}▒▒${reset}  
+ ${jinsf}▒▒▒▒${reset} ${boldon}${jinsf}▒▒${reset}   ${choef}▒▒▒▒${reset} ${boldon}${choef}▒▒${reset}   ${yvesf}▒▒▒▒${reset} ${boldon}${yvesf}▒▒${reset}   ${chuuf}▒▒▒▒${reset} ${boldon}${chuuf}▒▒${reset}   ${gowof}▒▒▒▒${reset} ${boldon}${gowof}▒▒${reset}   ${olivf}▒▒▒▒${reset} ${boldon}${olivf}▒▒${reset}
+ ${jinsf}▒▒ ■${reset} ${boldon}${jinsf}▒▒${reset}   ${choef}▒▒ ■${reset} ${boldon}${choef}▒▒${reset}   ${yvesf}▒▒ ■${reset} ${boldon}${yvesf}▒▒${reset}   ${chuuf}▒▒ ■${reset} ${boldon}${chuuf}▒▒${reset}   ${gowof}▒▒ ■${reset} ${boldon}${gowof}▒▒${reset}   ${olivf}▒▒ ■${reset} ${boldon}${olivf}▒▒${reset}
  ${jinsf}▒▒ ${reset}${boldon}${jinsf}▒▒▒▒${reset}   ${choef}▒▒ ${reset}${boldon}${choef}▒▒▒▒${reset}   ${yvesf}▒▒ ${reset}${boldon}${yvesf}▒▒▒▒${reset}   ${chuuf}▒▒ ${reset}${boldon}${chuuf}▒▒▒▒${reset}   ${gowof}▒▒ ${reset}${boldon}${gowof}▒▒▒▒${reset}   ${olivf}▒▒ ${reset}${boldon}${olivf}▒▒▒▒${reset}
 
 EOF

--- a/colorscripts/ganadara
+++ b/colorscripts/ganadara
@@ -1,21 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 my_dir="$(dirname "$0")"
 source $(dirname $0)/initialise.sh
 initializeANSI
 
-cat << EOF  
-  
+cat << EOF
+
 ${heejf}██████████${reset}  ${hyunf}██        ${reset}  ${hasef}██████████${reset}  ${yeojf}██████████${reset}  ${vivif}██████████${reset}  ${kimlf}██      ██${reset}
 ${heejf}        ██${reset}  ${hyunf}██        ${reset}  ${hasef}██        ${reset}  ${yeojf}        ██${reset}  ${vivif}██      ██${reset}  ${kimlf}██      ██${reset}
 ${heejf}        ██${reset}  ${hyunf}██        ${reset}  ${hasef}██        ${reset}  ${yeojf}██████████${reset}  ${vivif}██      ██${reset}  ${kimlf}██████████${reset}
 ${heejf}        ██${reset}  ${hyunf}██        ${reset}  ${hasef}██        ${reset}  ${yeojf}██        ${reset}  ${vivif}██      ██${reset}  ${kimlf}██      ██${reset}
 ${heejf}        ██${reset}  ${hyunf}██████████${reset}  ${hasef}██████████${reset}  ${yeojf}██████████${reset}  ${vivif}██████████${reset}  ${kimlf}██████████${reset}
 
-${jinsf}    ██    ${reset}  ${choef}  ██████  ${reset}  ${yvesf}██████████${reset}  ${chuuf}    ██    ${reset}  ${gowof}██████████${reset}  ${olivf}██████████${reset} 
+${jinsf}    ██    ${reset}  ${choef}  ██████  ${reset}  ${yvesf}██████████${reset}  ${chuuf}    ██    ${reset}  ${gowof}██████████${reset}  ${olivf}██████████${reset}
 ${jinsf}   ████   ${reset}  ${choef}██      ██${reset}  ${yvesf}   ████   ${reset}  ${chuuf}██████████${reset}  ${gowof}        ██${reset}  ${olivf}██         ${reset}
 ${jinsf}  ██  ██  ${reset}  ${choef}██      ██${reset}  ${yvesf}  ██████  ${reset}  ${chuuf}  ██████  ${reset}  ${gowof}  ████████${reset}  ${olivf}██████████${reset}
-${jinsf} ██    ██ ${reset}  ${choef}██      ██${reset}  ${yvesf} ███  ███ ${reset}  ${chuuf} ███  ███ ${reset}  ${gowof}        ██${reset}  ${olivf}██        ${reset} 
-${jinsf}██      ██${reset}  ${choef}  ██████  ${reset}  ${yvesf}███    ███${reset}  ${chuuf}███    ███${reset}  ${gowof}        ██${reset}  ${olivf}██████████${reset} 
+${jinsf} ██    ██ ${reset}  ${choef}██      ██${reset}  ${yvesf} ███  ███ ${reset}  ${chuuf} ███  ███ ${reset}  ${gowof}        ██${reset}  ${olivf}██        ${reset}
+${jinsf}██      ██${reset}  ${choef}  ██████  ${reset}  ${yvesf}███    ███${reset}  ${chuuf}███    ███${reset}  ${gowof}        ██${reset}  ${olivf}██████████${reset}
 
 EOF

--- a/colorscripts/ghosts
+++ b/colorscripts/ghosts
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ANSI color scheme script by pfh
 # Source: http://crunchbang.org/forums/viewtopic.php?pid=157979#p157979
 # Initializing mod by lolilolicon from Archlinux
@@ -9,15 +9,15 @@ initializeANSI
 
 cat << EOF
 
-$heejf    ▄▄▄      $hyunf    ▄▄▄      $hasef    ▄▄▄      $yeojf    ▄▄▄      $vivif    ▄▄▄      $kimlf    ▄▄▄     
-$heejf   ▀█▀██  ▄  $hyunf   ▀█▀██  ▄  $hasef   ▀█▀██  ▄  $yeojf   ▀█▀██  ▄  $vivif   ▀█▀██  ▄  $kimlf   ▀█▀██  ▄ 
-$heejf ▀▄██████▀   $hyunf ▀▄██████▀   $hasef ▀▄██████▀   $yeojf ▀▄██████▀   $vivif ▀▄██████▀   $kimlf ▀▄██████▀  
-$heejf    ▀█████   $hyunf    ▀█████   $hasef    ▀█████   $yeojf    ▀█████   $vivif    ▀█████   $kimlf    ▀█████  
+$heejf    ▄▄▄      $hyunf    ▄▄▄      $hasef    ▄▄▄      $yeojf    ▄▄▄      $vivif    ▄▄▄      $kimlf    ▄▄▄
+$heejf   ▀█▀██  ▄  $hyunf   ▀█▀██  ▄  $hasef   ▀█▀██  ▄  $yeojf   ▀█▀██  ▄  $vivif   ▀█▀██  ▄  $kimlf   ▀█▀██  ▄
+$heejf ▀▄██████▀   $hyunf ▀▄██████▀   $hasef ▀▄██████▀   $yeojf ▀▄██████▀   $vivif ▀▄██████▀   $kimlf ▀▄██████▀
+$heejf    ▀█████   $hyunf    ▀█████   $hasef    ▀█████   $yeojf    ▀█████   $vivif    ▀█████   $kimlf    ▀█████
 $heejf       ▀▀▀▀▄ $hyunf       ▀▀▀▀▄ $hasef       ▀▀▀▀▄ $yeojf       ▀▀▀▀▄ $vivif       ▀▀▀▀▄ $kimlf       ▀▀▀▀▄
 
-$jinsf    ▄▄▄      $choef    ▄▄▄      $yvesf    ▄▄▄      $chuuf    ▄▄▄      $gowof    ▄▄▄      $olivf    ▄▄▄     
-$jinsf   ▀█▀██  ▄  $choef   ▀█▀██  ▄  $yvesf   ▀█▀██  ▄  $chuuf   ▀█▀██  ▄  $gowof   ▀█▀██  ▄  $olivf   ▀█▀██  ▄ 
-$jinsf ▀▄██████▀   $choef ▀▄██████▀   $yvesf ▀▄██████▀   $chuuf ▀▄██████▀   $gowof ▀▄██████▀   $olivf ▀▄██████▀  
-$jinsf    ▀█████   $choef    ▀█████   $yvesf    ▀█████   $chuuf    ▀█████   $gowof    ▀█████   $olivf    ▀█████  
+$jinsf    ▄▄▄      $choef    ▄▄▄      $yvesf    ▄▄▄      $chuuf    ▄▄▄      $gowof    ▄▄▄      $olivf    ▄▄▄
+$jinsf   ▀█▀██  ▄  $choef   ▀█▀██  ▄  $yvesf   ▀█▀██  ▄  $chuuf   ▀█▀██  ▄  $gowof   ▀█▀██  ▄  $olivf   ▀█▀██  ▄
+$jinsf ▀▄██████▀   $choef ▀▄██████▀   $yvesf ▀▄██████▀   $chuuf ▀▄██████▀   $gowof ▀▄██████▀   $olivf ▀▄██████▀
+$jinsf    ▀█████   $choef    ▀█████   $yvesf    ▀█████   $chuuf    ▀█████   $gowof    ▀█████   $olivf    ▀█████
 $jinsf       ▀▀▀▀▄ $choef       ▀▀▀▀▄ $yvesf       ▀▀▀▀▄ $chuuf       ▀▀▀▀▄ $gowof       ▀▀▀▀▄ $olivf       ▀▀▀▀▄
 EOF

--- a/colorscripts/hearts
+++ b/colorscripts/hearts
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ANSI Color -- use these variables to easily have different color
-#    and format output. Make sure to output the reset sequence after 
+#    and format output. Make sure to output the reset sequence after
 #    colors (f = foreground, b = background), and use the 'off'
 #    feature for anything you turn on.
 
@@ -11,24 +11,24 @@ initializeANSI
 
 cat << EOF
 
-$heejf  ▄▄        ▄▄   $hyunf  ▄▄        ▄▄   $hasef  ▄▄        ▄▄   $yeojf  ▄▄        ▄▄   $vivif  ▄▄        ▄▄   $kimlf  ▄▄        ▄▄   
-$heejf▄█████▄  ▄█████▄ $hyunf▄█████▄  ▄█████▄ $hasef▄█████▄  ▄█████▄ $yeojf▄█████▄  ▄█████▄ $vivif▄█████▄  ▄█████▄ $kimlf▄█████▄  ▄█████▄ 
-$heejf███████▄▄███████ $hyunf███████▄▄███████ $hasef███████▄▄███████ $yeojf███████▄▄███████ $vivif███████▄▄███████ $kimlf███████▄▄███████ 
-$heejf████████████████ $hyunf████████████████ $hasef████████████████ $yeojf████████████████ $vivif████████████████ $kimlf████████████████ 
-$heejf████████████████ $hyunf████████████████ $hasef████████████████ $yeojf████████████████ $vivif████████████████ $kimlf████████████████ 
-$heejf████████████████ $hyunf████████████████ $hasef████████████████ $yeojf████████████████ $vivif████████████████ $kimlf████████████████ 
-$heejf  ████████████   $hyunf  ████████████   $hasef  ████████████   $yeojf  ████████████   $vivif  ████████████   $kimlf  ████████████   
-$heejf    ████████     $hyunf    ████████     $hasef    ████████     $yeojf    ████████     $vivif    ████████     $kimlf    ████████     
-$heejf      ████       $hyunf      ████       $hasef      ████       $yeojf      ████       $vivif      ████       $kimlf      ████       
+$heejf  ▄▄        ▄▄   $hyunf  ▄▄        ▄▄   $hasef  ▄▄        ▄▄   $yeojf  ▄▄        ▄▄   $vivif  ▄▄        ▄▄   $kimlf  ▄▄        ▄▄
+$heejf▄█████▄  ▄█████▄ $hyunf▄█████▄  ▄█████▄ $hasef▄█████▄  ▄█████▄ $yeojf▄█████▄  ▄█████▄ $vivif▄█████▄  ▄█████▄ $kimlf▄█████▄  ▄█████▄
+$heejf███████▄▄███████ $hyunf███████▄▄███████ $hasef███████▄▄███████ $yeojf███████▄▄███████ $vivif███████▄▄███████ $kimlf███████▄▄███████
+$heejf████████████████ $hyunf████████████████ $hasef████████████████ $yeojf████████████████ $vivif████████████████ $kimlf████████████████
+$heejf████████████████ $hyunf████████████████ $hasef████████████████ $yeojf████████████████ $vivif████████████████ $kimlf████████████████
+$heejf████████████████ $hyunf████████████████ $hasef████████████████ $yeojf████████████████ $vivif████████████████ $kimlf████████████████
+$heejf  ████████████   $hyunf  ████████████   $hasef  ████████████   $yeojf  ████████████   $vivif  ████████████   $kimlf  ████████████
+$heejf    ████████     $hyunf    ████████     $hasef    ████████     $yeojf    ████████     $vivif    ████████     $kimlf    ████████
+$heejf      ████       $hyunf      ████       $hasef      ████       $yeojf      ████       $vivif      ████       $kimlf      ████
 
-$jinsf  ▄▄        ▄▄   $choef  ▄▄        ▄▄   $yvesf  ▄▄        ▄▄   $chuuf  ▄▄        ▄▄   $gowof  ▄▄        ▄▄   $olivf  ▄▄        ▄▄   
-$jinsf▄█████▄  ▄█████▄ $choef▄█████▄  ▄█████▄ $yvesf▄█████▄  ▄█████▄ $chuuf▄█████▄  ▄█████▄ $gowof▄█████▄  ▄█████▄ $olivf▄█████▄  ▄█████▄ 
-$jinsf███████▄▄███████ $choef███████▄▄███████ $yvesf███████▄▄███████ $chuuf███████▄▄███████ $gowof███████▄▄███████ $olivf███████▄▄███████ 
-$jinsf████████████████ $choef████████████████ $yvesf████████████████ $chuuf████████████████ $gowof████████████████ $olivf████████████████ 
-$jinsf████████████████ $choef████████████████ $yvesf████████████████ $chuuf████████████████ $gowof████████████████ $olivf████████████████ 
-$jinsf████████████████ $choef████████████████ $yvesf████████████████ $chuuf████████████████ $gowof████████████████ $olivf████████████████ 
-$jinsf  ████████████   $choef  ████████████   $yvesf  ████████████   $chuuf  ████████████   $gowof  ████████████   $olivf  ████████████   
-$jinsf    ████████     $choef    ████████     $yvesf    ████████     $chuuf    ████████     $gowof    ████████     $olivf    ████████     
-$jinsf      ████       $choef      ████       $yvesf      ████       $chuuf      ████       $gowof      ████       $olivf      ████       
+$jinsf  ▄▄        ▄▄   $choef  ▄▄        ▄▄   $yvesf  ▄▄        ▄▄   $chuuf  ▄▄        ▄▄   $gowof  ▄▄        ▄▄   $olivf  ▄▄        ▄▄
+$jinsf▄█████▄  ▄█████▄ $choef▄█████▄  ▄█████▄ $yvesf▄█████▄  ▄█████▄ $chuuf▄█████▄  ▄█████▄ $gowof▄█████▄  ▄█████▄ $olivf▄█████▄  ▄█████▄
+$jinsf███████▄▄███████ $choef███████▄▄███████ $yvesf███████▄▄███████ $chuuf███████▄▄███████ $gowof███████▄▄███████ $olivf███████▄▄███████
+$jinsf████████████████ $choef████████████████ $yvesf████████████████ $chuuf████████████████ $gowof████████████████ $olivf████████████████
+$jinsf████████████████ $choef████████████████ $yvesf████████████████ $chuuf████████████████ $gowof████████████████ $olivf████████████████
+$jinsf████████████████ $choef████████████████ $yvesf████████████████ $chuuf████████████████ $gowof████████████████ $olivf████████████████
+$jinsf  ████████████   $choef  ████████████   $yvesf  ████████████   $chuuf  ████████████   $gowof  ████████████   $olivf  ████████████
+$jinsf    ████████     $choef    ████████     $yvesf    ████████     $chuuf    ████████     $gowof    ████████     $olivf    ████████
+$jinsf      ████       $choef      ████       $yvesf      ████       $chuuf      ████       $gowof      ████       $olivf      ████
 
 EOF

--- a/colorscripts/hedgehogs
+++ b/colorscripts/hedgehogs
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ANSI Color -- use these variables to easily have different color
-#    and format output. Make sure to output the reset sequence after 
+#    and format output. Make sure to output the reset sequence after
 #    colors (f = foreground, b = background), and use the 'off'
 #    feature for anything you turn on.
 

--- a/colorscripts/initialise.sh
+++ b/colorscripts/initialise.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 initializeANSI()
 {
   esc=""
@@ -9,7 +8,7 @@ initializeANSI()
   yeojf="${esc}[38;2;244;111;31m";
   vivif="${esc}[38;2;225;152;180m";
   kimlf="${esc}[38;2;228;26;62m";
-  jinsf="${esc}[38;2;20;36;176m"; 
+  jinsf="${esc}[38;2;20;36;176m";
   choef="${esc}[38;2;92;44;146m";
   yvesf="${esc}[38;2;126;0;47m";
   chuuf="${esc}[38;2;246;144;126m";
@@ -22,7 +21,7 @@ initializeANSI()
   yeojb="${esc}[48;2;244;111;31m";
   vivib="${esc}[48;2;225;152;180m";
   kimlb="${esc}[48;2;228;26;62m";
-  jinsb="${esc}[48;2;20;36;176m"; 
+  jinsb="${esc}[48;2;20;36;176m";
   choeb="${esc}[48;2;92;44;146m";
   yvesb="${esc}[48;2;126;0;47m";
   chuub="${esc}[48;2;246;144;126m";
@@ -33,10 +32,9 @@ initializeANSI()
   italicson="${esc}[3m"; italicsoff="${esc}[23m"
   ulon="${esc}[4m";      uloff="${esc}[24m"
   invon="${esc}[7m";     invoff="${esc}[27m"
-  
+
   white="${esc}[37m";
   reset="${esc}[0m";
 
   Bf="${esc}[30m"
 }
-

--- a/colorscripts/jangofett
+++ b/colorscripts/jangofett
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: pfh
 # Source: http://crunchbang.org/forums/viewtopic.php?pid=129265#p129265
 
@@ -9,15 +9,15 @@ initializeANSI
 cat << EOF
 
 ${heejf}   ▄█████▄ ${hyunf}   ▄█████▄ ${hasef}   ▄█████▄ ${yeojf}   ▄█████▄ ${vivif}   ▄█████▄ ${kimlf}   ▄█████▄
-${heejf}   █▄▄ ▄▄█ ${hyunf}   █▄▄ ▄▄█ ${hasef}   █▄▄ ▄▄█ ${yeojf}   █▄▄ ▄▄█ ${vivif}   █▄▄ ▄▄█ ${kimlf}   █▄▄ ▄▄█  
-${heejf}   ███ ███ ${hyunf}   ███ ███ ${hasef}   ███ ███ ${yeojf}   ███ ███ ${vivif}   ███ ███ ${kimlf}   ███ ███  
-${heejf}   ▀██ ██▀ ${hyunf}   ▀██ ██▀ ${hasef}   ▀██ ██▀ ${yeojf}   ▀██ ██▀ ${vivif}   ▀██ ██▀ ${kimlf}   ▀██ ██▀  
-${heejf}     ▀ ▀   ${hyunf}     ▀ ▀   ${hasef}     ▀ ▀   ${yeojf}     ▀ ▀   ${vivif}     ▀ ▀   ${kimlf}     ▀ ▀   
+${heejf}   █▄▄ ▄▄█ ${hyunf}   █▄▄ ▄▄█ ${hasef}   █▄▄ ▄▄█ ${yeojf}   █▄▄ ▄▄█ ${vivif}   █▄▄ ▄▄█ ${kimlf}   █▄▄ ▄▄█
+${heejf}   ███ ███ ${hyunf}   ███ ███ ${hasef}   ███ ███ ${yeojf}   ███ ███ ${vivif}   ███ ███ ${kimlf}   ███ ███
+${heejf}   ▀██ ██▀ ${hyunf}   ▀██ ██▀ ${hasef}   ▀██ ██▀ ${yeojf}   ▀██ ██▀ ${vivif}   ▀██ ██▀ ${kimlf}   ▀██ ██▀
+${heejf}     ▀ ▀   ${hyunf}     ▀ ▀   ${hasef}     ▀ ▀   ${yeojf}     ▀ ▀   ${vivif}     ▀ ▀   ${kimlf}     ▀ ▀
 
 ${jinsf}   ▄█████▄ ${choef}   ▄█████▄ ${yvesf}   ▄█████▄ ${chuuf}   ▄█████▄ ${gowof}   ▄█████▄ ${olivf}   ▄█████▄
-${jinsf}   █▄▄ ▄▄█ ${choef}   █▄▄ ▄▄█ ${yvesf}   █▄▄ ▄▄█ ${chuuf}   █▄▄ ▄▄█ ${gowof}   █▄▄ ▄▄█ ${olivf}   █▄▄ ▄▄█  
-${jinsf}   ███ ███ ${choef}   ███ ███ ${yvesf}   ███ ███ ${chuuf}   ███ ███ ${gowof}   ███ ███ ${olivf}   ███ ███  
-${jinsf}   ▀██ ██▀ ${choef}   ▀██ ██▀ ${yvesf}   ▀██ ██▀ ${chuuf}   ▀██ ██▀ ${gowof}   ▀██ ██▀ ${olivf}   ▀██ ██▀  
-${jinsf}     ▀ ▀   ${choef}     ▀ ▀   ${yvesf}     ▀ ▀   ${chuuf}     ▀ ▀   ${gowof}     ▀ ▀   ${olivf}     ▀ ▀   
+${jinsf}   █▄▄ ▄▄█ ${choef}   █▄▄ ▄▄█ ${yvesf}   █▄▄ ▄▄█ ${chuuf}   █▄▄ ▄▄█ ${gowof}   █▄▄ ▄▄█ ${olivf}   █▄▄ ▄▄█
+${jinsf}   ███ ███ ${choef}   ███ ███ ${yvesf}   ███ ███ ${chuuf}   ███ ███ ${gowof}   ███ ███ ${olivf}   ███ ███
+${jinsf}   ▀██ ██▀ ${choef}   ▀██ ██▀ ${yvesf}   ▀██ ██▀ ${chuuf}   ▀██ ██▀ ${gowof}   ▀██ ██▀ ${olivf}   ▀██ ██▀
+${jinsf}     ▀ ▀   ${choef}     ▀ ▀   ${yvesf}     ▀ ▀   ${chuuf}     ▀ ▀   ${gowof}     ▀ ▀   ${olivf}     ▀ ▀
 
 EOF

--- a/colorscripts/loonaen
+++ b/colorscripts/loonaen
@@ -1,11 +1,11 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 my_dir="$(dirname "$0")"
 source $(dirname $0)/initialise.sh
 
 initializeANSI
 
 cat << EOF
- 
+
  ${white} ██          ████      ████    ████████     ██    ${heejf}       ██ ${reset}
  ${white} ██        ██    ██  ██    ██  ██    ██    ████   ${heejf}     ██   ${reset}
  ${white} ██        ██    ██  ██    ██  ██    ██   ██  ██  ${heejf}   ██     ${reset}

--- a/colorscripts/loonakr
+++ b/colorscripts/loonakr
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 my_dir="$(dirname "$0")"
 source $(dirname $0)/initialise.sh
 
@@ -7,8 +7,8 @@ initializeANSI
 cat << EOF
 
  ${white}   ████    ████████
- ${white} ██    ██  ██      
- ${white} ██    ██  ██      
+ ${white} ██    ██  ██
+ ${white} ██    ██  ██
  ${white}   ████    ████████
 
  ${white}   ████   ${heejf}       ██ ${reset}
@@ -16,9 +16,9 @@ cat << EOF
  ${white} ██    ██ ${heejf}   ██     ${reset}
  ${white}   ████   ${heejf} ██       ${reset}
 
- ${white}    ██     ██      
- ${white}   ████    ██      
- ${white}  ██  ██   ██      
- ${white} ████████  ████████ 
+ ${white}    ██     ██
+ ${white}   ████    ██
+ ${white}  ██  ██   ██
+ ${white} ████████  ████████
 
 EOF

--- a/colorscripts/membershapes
+++ b/colorscripts/membershapes
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 my_dir="$(dirname "$0")"
 source $(dirname $0)/initialise.sh
 
@@ -16,9 +16,9 @@ cat << EOF
  ${kimlf} ████████ ${jinsf} ████████ ${choef} ████████
  ${kimlf} ▝▜████▛▘ ${jinsf} ▝▜████▛▘ ${choef} ▝▜████▛▘
 
- ${yvesf}    ██    ${chuuf}    ██    ${gowof} ████████ ${olivf}    ██    
- ${yvesf}   ████   ${chuuf}   ████   ${gowof}  ██████  ${olivf}   ████   
- ${yvesf}  ██████  ${chuuf}  ██████  ${gowof}   ████   ${olivf}  ██████  
- ${yvesf} ████████ ${chuuf} ████████ ${gowof}    ██    ${olivf} ████████ 
+ ${yvesf}    ██    ${chuuf}    ██    ${gowof} ████████ ${olivf}    ██
+ ${yvesf}   ████   ${chuuf}   ████   ${gowof}  ██████  ${olivf}   ████
+ ${yvesf}  ██████  ${chuuf}  ██████  ${gowof}   ████   ${olivf}  ██████
+ ${yvesf} ████████ ${chuuf} ████████ ${gowof}    ██    ${olivf} ████████
 
 EOF

--- a/colorscripts/monster
+++ b/colorscripts/monster
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: gutterslob
 # Source: http://crunchbang.org/forums/viewtopic.php?pid=130590#p130590
 

--- a/colorscripts/mouseface
+++ b/colorscripts/mouseface
@@ -1,5 +1,5 @@
-#!/bin/env bash
-# Author: ivo    
+#!/usr/bin/env bash
+# Author: ivo
 # Source: http://crunchbang.org/forums/viewtopic.php?pid=130522#p130522
 
 my_dir="$(dirname "$0")"
@@ -8,11 +8,11 @@ source $(dirname $0)/initialise.sh
 initializeANSI
 
 cat << EOF
- ${boldon}${heejf} █   █ ${reset} ${boldon}${hyunf}█   █ ${reset} ${boldon}${hasef}█   █ ${reset} ${boldon}${yeojf}█   █ ${reset} ${boldon}${vivif}█   █ ${reset} ${boldon}${kimlf}█   █ ${reset} 
+ ${boldon}${heejf} █   █ ${reset} ${boldon}${hyunf}█   █ ${reset} ${boldon}${hasef}█   █ ${reset} ${boldon}${yeojf}█   █ ${reset} ${boldon}${vivif}█   █ ${reset} ${boldon}${kimlf}█   █ ${reset}
  ${boldon}${heejf}  ■ ■  ${reset} ${boldon}${hyunf} ■ ■  ${reset} ${boldon}${hasef} ■ ■  ${reset} ${boldon}${yeojf} ■ ■  ${reset} ${boldon}${vivif} ■ ■  ${reset} ${boldon}${kimlf} ■ ■  ${reset}
  ${boldon}${heejf}  =■=  ${reset} ${boldon}${hyunf} =■=  ${reset} ${boldon}${hasef} =■=  ${reset} ${boldon}${yeojf} =■=  ${reset} ${boldon}${vivif} =■=  ${reset} ${boldon}${kimlf} =■=  ${reset}
- 
+
  ${jinsf} █=@=█ ${reset} ${choef}█=@=█ ${reset} ${yvesf}█=@=█ ${reset} ${chuuf}█=@=█ ${reset} ${gowof}█=@=█ ${reset} ${olivf}█=@=█ ${reset}
  ${jinsf}  ■ ■  ${reset} ${choef} ■ ■  ${reset} ${yvesf} ■ ■  ${reset} ${chuuf} ■ ■  ${reset} ${gowof} ■ ■  ${reset} ${olivf} ■ ■  ${reset}
- ${jinsf}  =■=  ${reset} ${choef} =■=  ${reset} ${yvesf} =■=  ${reset} ${chuuf} =■=  ${reset} ${gowof} =■=  ${reset} ${olivf} =■=  ${reset} 
+ ${jinsf}  =■=  ${reset} ${choef} =■=  ${reset} ${yvesf} =■=  ${reset} ${chuuf} =■=  ${reset} ${gowof} =■=  ${reset} ${olivf} =■=  ${reset}
 EOF

--- a/colorscripts/mouseface2
+++ b/colorscripts/mouseface2
@@ -1,9 +1,9 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #    Author: Ivo
 #  	 Source: http://crunchbang.org/forums/viewtopic.php?pid=150114#p150114
 #    ANSI Color -- use these variables to easily have different color
-#    and format output. Make sure to output the reset sequence after 
+#    and format output. Make sure to output the reset sequence after
 #    colors (f = foreground, b = background), and use the 'off'
 #    feature for anything you turn on.
 
@@ -14,15 +14,15 @@ initializeANSI
 
 cat << EOF
 
-${boldon}${heejf}   ██     ██ ${reset} ${boldon}${hyunf}   ██     ██ ${reset} ${boldon}${hasef}   ██     ██ ${reset} ${boldon}${yeojf}   ██     ██ ${reset} ${boldon}${vivif}   ██     ██ ${reset} ${boldon}${kimlf}   ██     ██ ${reset} 
-${boldon}${heejf}  █${whitef} ■${reset}${boldon}${heejf}█   █${whitef}■${reset}${boldon}${heejf} █${reset} ${boldon}${hyunf}  █${whitef} ■${reset}${boldon}${hyunf}█   █${whitef}■${reset}${boldon}${hyunf} █${reset} ${boldon}${hasef}  █${whitef} ■${reset}${boldon}${hasef}█   █${whitef}■${reset}${boldon}${hasef} █${reset} ${boldon}${yeojf}  █${whitef} ■${reset}${boldon}${yeojf}█   █${whitef}■${reset}${boldon}${yeojf} █${reset} ${boldon}${vivif}  █${whitef} ■${reset}${boldon}${vivif}█   █${whitef}■${reset}${boldon}${vivif} █${reset} ${boldon}${kimlf}  █${whitef} ■${reset}${boldon}${kimlf}█   █${whitef}■${reset}${boldon}${kimlf} █${reset} 
+${boldon}${heejf}   ██     ██ ${reset} ${boldon}${hyunf}   ██     ██ ${reset} ${boldon}${hasef}   ██     ██ ${reset} ${boldon}${yeojf}   ██     ██ ${reset} ${boldon}${vivif}   ██     ██ ${reset} ${boldon}${kimlf}   ██     ██ ${reset}
+${boldon}${heejf}  █${whitef} ■${reset}${boldon}${heejf}█   █${whitef}■${reset}${boldon}${heejf} █${reset} ${boldon}${hyunf}  █${whitef} ■${reset}${boldon}${hyunf}█   █${whitef}■${reset}${boldon}${hyunf} █${reset} ${boldon}${hasef}  █${whitef} ■${reset}${boldon}${hasef}█   █${whitef}■${reset}${boldon}${hasef} █${reset} ${boldon}${yeojf}  █${whitef} ■${reset}${boldon}${yeojf}█   █${whitef}■${reset}${boldon}${yeojf} █${reset} ${boldon}${vivif}  █${whitef} ■${reset}${boldon}${vivif}█   █${whitef}■${reset}${boldon}${vivif} █${reset} ${boldon}${kimlf}  █${whitef} ■${reset}${boldon}${kimlf}█   █${whitef}■${reset}${boldon}${kimlf} █${reset}
 ${heejf}   █ █   █ █ ${reset} ${hyunf}   █ █   █ █ ${reset} ${hasef}   █ █   █ █ ${reset} ${yeojf}   █ █   █ █ ${reset} ${vivif}   █ █   █ █ ${reset} ${kimlf}   █ █   █ █ ${reset}
 ${heejf}     █ █ █   ${reset} ${hyunf}     █ █ █   ${reset} ${hasef}     █ █ █   ${reset} ${yeojf}     █ █ █   ${reset} ${vivif}     █ █ █   ${reset} ${kimlf}     █ █ █   ${reset}
-${heejf}      =■=    ${reset} ${hyunf}      =■=    ${reset} ${hasef}      =■=    ${reset} ${yeojf}      =■=    ${reset} ${vivif}      =■=    ${reset} ${kimlf}      =■=    ${reset}      
-${boldon}${jinsf}   ██     ██ ${reset} ${boldon}${choef}   ██     ██ ${reset} ${boldon}${yvesf}   ██     ██ ${reset} ${boldon}${chuuf}   ██     ██ ${reset} ${boldon}${gowof}   ██     ██ ${reset} ${boldon}${olivf}   ██     ██ ${reset} 
-${boldon}${jinsf}  █${whitef} ■${reset}${boldon}${jinsf}█   █${whitef}■${reset}${boldon}${jinsf} █${reset} ${boldon}${choef}  █${whitef} ■${reset}${boldon}${choef}█   █${whitef}■${reset}${boldon}${choef} █${reset} ${boldon}${yvesf}  █${whitef} ■${reset}${boldon}${yvesf}█   █${whitef}■${reset}${boldon}${yvesf} █${reset} ${boldon}${chuuf}  █${whitef} ■${reset}${boldon}${chuuf}█   █${whitef}■${reset}${boldon}${chuuf} █${reset} ${boldon}${gowof}  █${whitef} ■${reset}${boldon}${gowof}█   █${whitef}■${reset}${boldon}${gowof} █${reset} ${boldon}${olivf}  █${whitef} ■${reset}${boldon}${olivf}█   █${whitef}■${reset}${boldon}${olivf} █${reset} 
+${heejf}      =■=    ${reset} ${hyunf}      =■=    ${reset} ${hasef}      =■=    ${reset} ${yeojf}      =■=    ${reset} ${vivif}      =■=    ${reset} ${kimlf}      =■=    ${reset}
+${boldon}${jinsf}   ██     ██ ${reset} ${boldon}${choef}   ██     ██ ${reset} ${boldon}${yvesf}   ██     ██ ${reset} ${boldon}${chuuf}   ██     ██ ${reset} ${boldon}${gowof}   ██     ██ ${reset} ${boldon}${olivf}   ██     ██ ${reset}
+${boldon}${jinsf}  █${whitef} ■${reset}${boldon}${jinsf}█   █${whitef}■${reset}${boldon}${jinsf} █${reset} ${boldon}${choef}  █${whitef} ■${reset}${boldon}${choef}█   █${whitef}■${reset}${boldon}${choef} █${reset} ${boldon}${yvesf}  █${whitef} ■${reset}${boldon}${yvesf}█   █${whitef}■${reset}${boldon}${yvesf} █${reset} ${boldon}${chuuf}  █${whitef} ■${reset}${boldon}${chuuf}█   █${whitef}■${reset}${boldon}${chuuf} █${reset} ${boldon}${gowof}  █${whitef} ■${reset}${boldon}${gowof}█   █${whitef}■${reset}${boldon}${gowof} █${reset} ${boldon}${olivf}  █${whitef} ■${reset}${boldon}${olivf}█   █${whitef}■${reset}${boldon}${olivf} █${reset}
 ${jinsf}   █ █   █ █ ${reset} ${choef}   █ █   █ █ ${reset} ${yvesf}   █ █   █ █ ${reset} ${chuuf}   █ █   █ █ ${reset} ${gowof}   █ █   █ █ ${reset} ${olivf}   █ █   █ █ ${reset}
 ${jinsf}     █ █ █   ${reset} ${choef}     █ █ █   ${reset} ${yvesf}     █ █ █   ${reset} ${chuuf}     █ █ █   ${reset} ${gowof}     █ █ █   ${reset} ${olivf}     █ █ █   ${reset}
-${jinsf}      =■=    ${reset} ${choef}      =■=    ${reset} ${yvesf}      =■=    ${reset} ${chuuf}      =■=    ${reset} ${gowof}      =■=    ${reset} ${olivf}      =■=    ${reset}                                                
+${jinsf}      =■=    ${reset} ${choef}      =■=    ${reset} ${yvesf}      =■=    ${reset} ${chuuf}      =■=    ${reset} ${gowof}      =■=    ${reset} ${olivf}      =■=    ${reset}
 
 EOF

--- a/loonascripts
+++ b/loonascripts
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 # Simple CLI for shell-color-scripts
 
@@ -18,7 +18,7 @@ fi
 
 list_colorscripts="$($LS_CMD | xargs -I $ basename $ | cut -d ' ' -f 1 | nl)"
 length_colorscripts="$($LS_CMD | wc -l)"
-list_blacklist="$($LS_CMD_B 2>/dev/null | xargs -I $ basename $ | cut -d ' ' -f 1 | nl || "")" 
+list_blacklist="$($LS_CMD_B 2>/dev/null | xargs -I $ basename $ | cut -d ' ' -f 1 | nl || "")"
 length_blacklist="$($LS_CMD_B 2>/dev/null | wc -l || 0)"
 
 fmt_help="  %-20s\t%-54s\n"


### PR DESCRIPTION
Fixes and standardizes paths to bash on `#!/usr/bin/env bash`. The new scripts `loonaen`, etc., all fail on many Unix-like systems; `/bin/env` is nonstandard, `/usr/bin/env` has been the more common location for all Linux distros since the late 90s, and any distros that do have a `/bin/env` should most likely have a symlink to `/usr/bin/env`.

I also removed the executable bit from `initialise` because it's only intended to be sourced, not run; and there's some extra diff from Vim automatically trimming trailing whitespace but it does not affect functionality.